### PR TITLE
Add cluster support for ClickHouse

### DIFF
--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -272,18 +272,6 @@ func (ch *ClickHouse) SetVersion(version int, dirty bool) error {
 			return &database.Error{OrigErr: err, Query: []byte(query)}
 		}
 	}
-
-	// insert into local table
-	query := fmt.Sprintf(
-		"INSERT INTO %s VALUES (%d, %d, %d)",
-		ch.config.MigrationsTable,
-		version,
-		bool(dirty),
-		timeNow,
-	)
-	if _, err := tx.Exec(query); err != nil {
-		return &database.Error{OrigErr: err, Query: []byte(query)}
-	}
 	return tx.Commit()
 }
 

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -208,7 +208,11 @@ func (ch *ClickHouse) HostAddrs() ([]string, error) {
 	if len(hostAddrs) != 0 {
 		// connect to other host and do the same thing
 		for hostAddr := range hostAddrs {
-			ch.url.Host = hostAddr
+			port := ch.url.Port()
+			if port == "" {
+				port = "9000"
+			}
+			ch.url.Host = hostAddr + ":" + port
 			conn, err := sql.Open("clickhouse", ch.url.String())
 			if err != nil {
 				return nil, err

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -82,7 +82,6 @@ func (ch *ClickHouse) Open(dsn string) (database.Driver, error) {
 	if err != nil {
 		return nil, err
 	}
-	ch.url = q
 
 	multiStatementMaxSize := DefaultMultiStatementMaxSize
 	if s := purl.Query().Get("x-multi-statement-max-size"); len(s) > 0 {
@@ -107,6 +106,7 @@ func (ch *ClickHouse) Open(dsn string) (database.Driver, error) {
 			MultiStatementEnabled: purl.Query().Get("x-multi-statement") == "true",
 			MultiStatementMaxSize: multiStatementMaxSize,
 		},
+		url: q,
 	}
 
 	if err := ch.init(); err != nil {

--- a/database/clickhouse/clickhouse.go
+++ b/database/clickhouse/clickhouse.go
@@ -219,8 +219,9 @@ func (ch *ClickHouse) SetVersion(version int, dirty bool) error {
 	// insert into remote table(s)
 	for _, hostAddr := range hostAddrs {
 		query := fmt.Sprintf(
-			"INSERT INTO FUNCTION remote('%s', %s) VALUES (%d, %d, %d)",
+			"INSERT INTO FUNCTION remote('%s', %s, %s) VALUES (%d, %d, %d)",
 			hostAddr,
+			ch.config.DatabaseName,
 			ch.config.MigrationsTable,
 			version,
 			bool(dirty),


### PR DESCRIPTION
Currently, the completed migration only inserts the data into the shard it is connected to, causing migration to run again when it is connected to a different shard. 

We want to insert the same data into all shards of all replicas. This can't be achieved with distributed table engine because it requires sharding data which is not desired because we want same data in all shards not some randomly distributed data.

To achieve this we make use of `INSERT INTO FUNCTION remote ...` https://clickhouse.com/docs/en/sql-reference/statements/insert-into#inserting-using-a-table-function. This inserts the data into all other instances of ClickHouse shard/replica. The hosts are obtained by querying the `system.clusters` table. However, this table contains one entry with `localhost` for the shard we are connected to, so we ignore that entry and then write to connected shard separately.


## Cons of this approach

You can't run from anywhere out the n/w of ClickHouse instance running ex (you can't run from a local machine). Should I make it configurable where it tries to write to remote instances?